### PR TITLE
Another problem was found when there were multiple loads pending for …

### DIFF
--- a/O2DESNet.RCQueues/RCQsModel.cs
+++ b/O2DESNet.RCQueues/RCQsModel.cs
@@ -600,7 +600,12 @@ namespace O2DESNet.RCQueues
                 }
 
                 moveTo.Phase = BatchPhase.Started;
-                                        
+
+                /// check for the next batch in the same activity
+                if (_activityToBatchTimes_Pending[moveTo.Activity].Count > 0) 
+                    Schedule(() => AttemptToStart(_activityToBatchTimes_Pending[moveTo.Activity].First().Batch));
+
+                /// check for released resource
                 RecallForPending(released.Keys);
             }
             #endregion


### PR DESCRIPTION
…the same activity, for which a bundle of resources was released. In "RecallForPending" method, there shall be a recursive call for the same activity until there is no pending load or the resource is not sufficient.